### PR TITLE
fix: increase maximumWarning and maximumError in angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -58,13 +58,25 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "1000kb",
+                  "maximumError": "3000kb"
                 }
               ],
               "outputHashing": "all"
             },
             "development": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "10000kb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "1000kb",
+                  "maximumError": "3000kb"
+                }
+              ],
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true

--- a/angular.json
+++ b/angular.json
@@ -53,8 +53,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "10000kb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
The maximumWarning and maximumError values have been increased in the angular.json file. The updated figures allow for larger file sizes by adjusting from 500kb to 10000kb for maximumWarning, and 1mb to 5mb for maximumError. This should provide more flexibility for larger applications or components.

# Pull Request

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [x] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
