### PR TITLE
fix: update GitHub Actions workflow settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          persist-credentials: false # This is important to avoid conflicts with the deploy step
+          persist-credentials: true
+          fetch-depth: 0 # Fetch all history for all tags and branches
 
       - uses: actions/setup-node@v2
         with:
@@ -29,7 +30,7 @@ jobs:
           git checkout -b gh-pages
           git add -f dist/portfolio/browser
           git commit -m "Deploy to GitHub Pages"
-          git push origin `git subtree split --prefix dist/portfolio/browser gh-pages`:gh-pages --force
+          git push origin gh-pages --force --quiet
 
   semantic-release:
     needs: build-and-deploy


### PR DESCRIPTION
Changed the persist-credentials setting to 'true' and added fetch-depth to the checkout step in release.yml to fetch all history for tags and branches. Also, simplified the 'git push' command in the gh-pages deployment script.

# Pull Request

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [x] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
