### PR TITLE
fix: update release workflow for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: true
-          fetch-depth: 0 # Fetch all history for all tags and branches
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2
         with:
@@ -28,7 +28,9 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout -b gh-pages
-          git add -f dist/portfolio/browser
+          git rm -rf .
+          cp -r dist/portfolio/browser/* .
+          git add .
           git commit -m "Deploy to GitHub Pages"
           git push origin gh-pages --force --quiet
 


### PR DESCRIPTION
Adjusted fetch-depth setting to fetch all history for all tags and branches in the checkout step of the GitHub Actions workflow in release.yml. Furthermore, the 'git add' and 'git rm' steps have been streamlined to improve the efficiency of the gh-pages deployment script.

# Pull Request

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [ ] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
