### PR TITLE
fix: update fetch-depth comment in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: true
-          fetch-depth: 0
+          fetch-depth: 0 # Fetch all history for all tags and branches
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
The fetch-depth attribute in the .github/workflows/release.yml file has been updated. A comment explaining that it's set to fetch all history for all tags and branches has been added right after it.

# Pull Request

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [ ] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
