### PR TITLE
fix: update ng build command in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run: npm install -g @angular/cli
       - run: npm install
-      - run: ng build --base-href https://danieljancar.dev
+      - run: ng build --base-href https://danieljancar.dev --exclude=node_modules
 
       - name: Deploy to gh-pages
         run: |


### PR DESCRIPTION
The ng build command in the .github/workflows/release.yml file has been modified. It now includes an option to exclude node_modules, which should streamline the build process.

# Pull Request

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [ ] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
