### PR TITLE
fix: update add command in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run: npm install -g @angular/cli
       - run: npm install
-      - run: ng build --base-href https://danieljancar.dev --exclude=node_modules
+      - run: ng build --base-href https://danieljancar.dev
 
       - name: Deploy to gh-pages
         run: |
@@ -30,7 +30,7 @@ jobs:
           git checkout -b gh-pages
           git rm -rf .
           cp -r dist/portfolio/browser/* .
-          git add .
+          git add .gitignore
           git commit -m "Deploy to GitHub Pages"
           git push origin gh-pages --force --quiet
 


### PR DESCRIPTION
The `git add` command in the .github/workflows/release.yml file has been updated to only add the .gitignore file and no longer includes everything. This adjustment ensures only essential files are added to the commit during the deployment to GitHub Pages process.

# Pull Request

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [x] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](../DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
